### PR TITLE
Add gofmt -s formatting and pre-commit hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,11 @@
+#!/bin/sh
+# Pre-commit hook: reject unformatted Go files
+
+UNFORMATTED=$(gofmt -s -l . 2>/dev/null)
+if [ -n "$UNFORMATTED" ]; then
+  echo "gofmt -s: these files are not formatted:"
+  echo "$UNFORMATTED"
+  echo ""
+  echo "Run: gofmt -s -w ."
+  exit 1
+fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,15 @@ jobs:
       - name: Build
         run: go build ./...
 
+      - name: Format check
+        run: |
+          UNFORMATTED=$(gofmt -s -l .)
+          if [ -n "$UNFORMATTED" ]; then
+            echo "gofmt -s: these files are not formatted:"
+            echo "$UNFORMATTED"
+            exit 1
+          fi
+
       - name: Vet
         run: go vet ./...
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 BINARY_NAME = otel_trace_hook
 INSTALL_DIR = $(HOME)/.claude/hooks
 
-.PHONY: build install clean test test-race test-cover
+.PHONY: build install clean test test-race test-cover fmt setup-hooks
 
 build:
 	go build -o $(BINARY_NAME) .
@@ -22,3 +22,9 @@ test-race:
 
 test-cover:
 	go test -cover ./...
+
+fmt:
+	gofmt -s -w .
+
+setup-hooks:
+	git config core.hooksPath .githooks

--- a/main.go
+++ b/main.go
@@ -242,8 +242,8 @@ func handleStop(input HookInput) {
 	// Update state.
 	ss.LastLine = totalLines
 	ss.TurnCount += len(turns)
-	ss.ToolSpans = nil          // Clear after export.
-	ss.PendingSubagents = nil   // Clear after export.
+	ss.ToolSpans = nil        // Clear after export.
+	ss.PendingSubagents = nil // Clear after export.
 	ss.Updated = time.Now()
 
 	if err := saveState(sf); err != nil {

--- a/tracer_test.go
+++ b/tracer_test.go
@@ -123,13 +123,13 @@ func TestExportSessionTrace_SingleTurn(t *testing.T) {
 
 	turns := []Turn{
 		{
-			Number:      1,
-			Model:       "claude-sonnet-4-20250514",
-			InputTokens: 100,
+			Number:       1,
+			Model:        "claude-sonnet-4-20250514",
+			InputTokens:  100,
 			OutputTokens: 20,
-			StopReason:  "end_turn",
-			StartTime:   now,
-			EndTime:     now.Add(2 * time.Second),
+			StopReason:   "end_turn",
+			StartTime:    now,
+			EndTime:      now.Add(2 * time.Second),
 		},
 	}
 

--- a/transcript.go
+++ b/transcript.go
@@ -333,7 +333,7 @@ func parseTranscript(transcriptPath string, startLine int) ([]Turn, int, error) 
 		turns = append(turns, Turn{
 			Number:              turnNum,
 			UserText:            userText,
-			UserTimestamp:        userTS,
+			UserTimestamp:       userTS,
 			AssistantMessages:   currentAssistants,
 			ToolCalls:           toolCalls,
 			Model:               model,

--- a/transcript_test.go
+++ b/transcript_test.go
@@ -148,9 +148,9 @@ func TestExtractUsage(t *testing.T) {
 	msg := map[string]interface{}{
 		"message": map[string]interface{}{
 			"usage": map[string]interface{}{
-				"input_tokens":              100.0,
-				"output_tokens":             50.0,
-				"cache_read_input_tokens":   30.0,
+				"input_tokens":                100.0,
+				"output_tokens":               50.0,
+				"cache_read_input_tokens":     30.0,
 				"cache_creation_input_tokens": 10.0,
 			},
 		},

--- a/types.go
+++ b/types.go
@@ -4,15 +4,15 @@ import "time"
 
 // HookInput represents the JSON received on stdin from Claude Code hooks.
 type HookInput struct {
-	SessionID      string                 `json:"session_id"`
-	TranscriptPath string                 `json:"transcript_path"`
-	CWD            string                 `json:"cwd"`
-	HookEventName  string                 `json:"hook_event_name"`
+	SessionID      string `json:"session_id"`
+	TranscriptPath string `json:"transcript_path"`
+	CWD            string `json:"cwd"`
+	HookEventName  string `json:"hook_event_name"`
 
 	// PostToolUse fields
 	ToolName     string                 `json:"tool_name,omitempty"`
 	ToolInput    map[string]interface{} `json:"tool_input,omitempty"`
-	ToolResponse interface{}             `json:"tool_response,omitempty"`
+	ToolResponse interface{}            `json:"tool_response,omitempty"`
 	ToolUseID    string                 `json:"tool_use_id,omitempty"`
 
 	// SubagentStop fields
@@ -39,12 +39,12 @@ type PendingSubagent struct {
 
 // SessionState persists between hook invocations for one session.
 type SessionState struct {
-	SessionSpanID  string         `json:"session_span_id"`
-	SessionStart   time.Time      `json:"session_start"`
-	TranscriptPath string         `json:"transcript_path"`
-	CWD            string         `json:"cwd"`
-	LastLine       int            `json:"last_line"`
-	TurnCount      int            `json:"turn_count"`
+	SessionSpanID    string            `json:"session_span_id"`
+	SessionStart     time.Time         `json:"session_start"`
+	TranscriptPath   string            `json:"transcript_path"`
+	CWD              string            `json:"cwd"`
+	LastLine         int               `json:"last_line"`
+	TurnCount        int               `json:"turn_count"`
 	ToolSpans        []ToolSpanData    `json:"tool_spans"`
 	PendingSubagents []PendingSubagent `json:"pending_subagents,omitempty"`
 	Updated          time.Time         `json:"updated"`
@@ -59,7 +59,7 @@ type StateFile struct {
 type Turn struct {
 	Number              int
 	UserText            string
-	UserTimestamp        time.Time
+	UserTimestamp       time.Time
 	AssistantMessages   []map[string]interface{}
 	ToolCalls           []ToolCall
 	Model               string


### PR DESCRIPTION
## Summary
- Apply `gofmt -s` to all Go files (fixes Go Report Card gofmt score from 50% to 100%)
- Add `.githooks/pre-commit` hook to reject unformatted code at commit time
- Add format check step to CI workflow (before `go vet`)
- Add `make fmt` and `make setup-hooks` Makefile targets

## Setup
After cloning, run `make setup-hooks` to activate the pre-commit hook.

## Related
- Closes gofmt portion of [Go Report Card](https://goreportcard.com/report/github.com/nadersoliman/cc-trace) findings
- Cyclomatic complexity tracked separately in #9

## Test plan
- [ ] CI triggers and format check passes
- [ ] `gofmt -s -l .` returns no output
- [ ] Pre-commit hook rejects unformatted files

🤖 Generated with [Claude Code](https://claude.com/claude-code)