### PR TITLE
Add PostToolUseFailure to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,9 +12,9 @@ make install    # builds and copies binary to ~/.claude/hooks/otel_trace_hook
 
 ## Architecture
 
-Short-lived CLI invoked by Claude Code on **PostToolUse**, **SubagentStop**, and **Stop** hook events via stdin JSON.
+Short-lived CLI invoked by Claude Code on **PostToolUse**, **PostToolUseFailure**, **SubagentStop**, and **Stop** hook events via stdin JSON.
 
-- **PostToolUse** (< 10ms, no network): Records tool data to `~/.claude/state/otel_trace_state.json`
+- **PostToolUse / PostToolUseFailure** (< 10ms, no network): Records tool data to `~/.claude/state/otel_trace_state.json`
 - **SubagentStop** (< 50ms, no network): Parses subagent transcript and stores for later export
 - **Stop** (< 2s): Parses JSONL transcript, creates OTel spans, exports via OTLP/HTTP, updates state
 


### PR DESCRIPTION
## Summary
- Add `PostToolUseFailure` to CLAUDE.md architecture section (was missing alongside `PostToolUse`)
- The code already handles both events identically (`case "PostToolUse", "PostToolUseFailure"`)
- README already included it in the config example

Also cleaned up stale Entire CLI git hooks locally (untracked files, not part of this diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)