### PR TITLE
feat: support HTTPS OTLP endpoints

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,7 @@ All configuration follows the [OTel environment variable specification](https://
 
 | Variable | OTel Spec Default | Purpose |
 |----------|-------------------|---------|
-| `OTEL_EXPORTER_OTLP_ENDPOINT` | `http://localhost:4318` | Base OTLP endpoint. The HTTP exporter appends `/v1/traces` automatically. Shared with Claude Code's metrics/logs -- no separate traces endpoint needed. |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | `http://localhost:4318` | Base OTLP endpoint. Supports both `http://` and `https://` schemes. The HTTP exporter appends `/v1/traces` automatically. Shared with Claude Code's metrics/logs -- no separate traces endpoint needed. |
 | `OTEL_SERVICE_NAME` | `unknown_service` | `service.name` resource attribute |
 | `OTEL_RESOURCE_ATTRIBUTES` | (none) | Comma-separated `key=value` pairs added to the trace resource (e.g., `project.name=k8s-lab`) |
 | `CC_TRACE_DEBUG` | `false` | Debug logging to `~/.claude/state/cc_trace.log` |
@@ -68,7 +68,7 @@ All configuration follows the [OTel environment variable specification](https://
 | `CC_TRACE_DUMP` | `false` | Dump raw hook payloads and transcripts to `/tmp/cc-trace/dumps/` for investigation |
 | `CC_TRACE_ROTATE` | `false` | Rotate trace ID per session segment. Each SessionStart (startup/resume/clear/compact) on an existing session creates a new trace, preventing long-lived sessions from outliving backend retention. Ignored when `TRACEPARENT` is set. |
 
-**Note:** The hook previously used gRPC (`otlptracegrpc`, port 4317) with a separate `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`. It now uses HTTP/protobuf (`otlptracehttp`) to share the same `OTEL_EXPORTER_OTLP_ENDPOINT` as Claude Code's metrics and logs. Per the OTel spec, the HTTP exporter appends `/v1/traces` to the base endpoint automatically.
+**Note:** The hook previously used gRPC (`otlptracegrpc`, port 4317) with a separate `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`. It now uses HTTP/protobuf (`otlptracehttp`) to share the same `OTEL_EXPORTER_OTLP_ENDPOINT` as Claude Code's metrics and logs. Per the OTel spec, the HTTP exporter appends `/v1/traces` to the base endpoint automatically. TLS is enabled automatically for `https://` endpoints; set `OTEL_EXPORTER_OTLP_HEADERS` for auth headers.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -60,9 +60,10 @@ Add to your global Claude Code settings (`~/.claude/settings.json`):
 
 | Variable | Default | Purpose |
 |----------|---------|---------|
-| `OTEL_EXPORTER_OTLP_ENDPOINT` | `http://localhost:4318` | OTLP/HTTP endpoint (appends `/v1/traces`) |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | `http://localhost:4318` | OTLP endpoint -- `http://` or `https://` (appends `/v1/traces`) |
 | `OTEL_SERVICE_NAME` | `unknown_service` | `service.name` resource attribute |
 | `OTEL_RESOURCE_ATTRIBUTES` | — | Comma-separated `key=value` pairs (e.g. `project.name=myapp`) |
+| `OTEL_EXPORTER_OTLP_HEADERS` | — | Comma-separated `key=value` headers for OTLP requests (e.g. `Authorization=Bearer xxx`). Read automatically by the OTel SDK |
 | `CC_TRACE_DEBUG` | `false` | Debug log to `~/.claude/state/cc_trace.log` |
 | `CC_TRACE_TIMING` | `false` | Phase-level timing logs to `~/.claude/state/cc_trace.log` |
 | `CC_TRACE_DUMP` | `false` | Dump raw hook payloads and transcripts to `/tmp/cc-trace/dumps/` |

--- a/docs/plans/2026-03-28-https-endpoint-support-implementation.md
+++ b/docs/plans/2026-03-28-https-endpoint-support-implementation.md
@@ -1,0 +1,197 @@
+# HTTPS Endpoint Support Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Support HTTPS OTLP endpoints by removing the hardcoded `WithInsecure()` and applying it only for `http://` schemes.
+
+**Architecture:** Extract scheme detection into a testable helper (`isInsecureEndpoint`), use it in `InitTracer` to conditionally apply `WithInsecure()`. The OTel SDK default is HTTPS, so omitting `WithInsecure()` enables TLS automatically. The SDK already reads `OTEL_EXPORTER_OTLP_HEADERS` for auth headers.
+
+**Tech Stack:** Go, OTel SDK (`go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp`)
+
+---
+
+### Task 1: Write failing tests for scheme detection
+
+**Files:**
+- Modify: `internal/tracer/tracer_test.go`
+
+**Step 1: Write the test**
+
+Add at the end of `internal/tracer/tracer_test.go`:
+
+```go
+func TestIsInsecureEndpoint(t *testing.T) {
+	tests := []struct {
+		name     string
+		endpoint string
+		traces   string
+		want     bool
+	}{
+		{"http explicit", "http://localhost:4318", "", true},
+		{"https explicit", "https://otel.example.com", "", true},
+		{"empty defaults to insecure", "", "", true},
+		{"traces endpoint http", "", "http://localhost:4318/v1/traces", true},
+		{"traces endpoint https", "", "https://otel.example.com/v1/traces", false},
+		{"endpoint takes precedence", "https://otel.example.com", "http://localhost:4318/v1/traces", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", tt.endpoint)
+			t.Setenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", tt.traces)
+			if got := isInsecureEndpoint(); got != tt.want {
+				t.Errorf("isInsecureEndpoint() = %v, want %v (endpoint=%q traces=%q)", got, tt.want, tt.endpoint, tt.traces)
+			}
+		})
+	}
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd /Users/nadersoliman/projects/cc-trace && go test ./internal/tracer/ -run TestIsInsecureEndpoint -v 2>&1 | head -5`
+Expected: FAIL — `isInsecureEndpoint` undefined
+
+**Step 3: Commit**
+
+```bash
+git add internal/tracer/tracer_test.go
+git commit -m "test: add failing tests for HTTPS endpoint detection" --author="Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Implement isInsecureEndpoint and update InitTracer
+
+**Files:**
+- Modify: `internal/tracer/tracer.go:42-55`
+
+**Step 1: Add the isInsecureEndpoint helper**
+
+Add after the `traceIDFromSession` function (after line 34), before `InitTracer`:
+
+```go
+// isInsecureEndpoint checks the configured OTLP endpoint scheme.
+// Returns true if the endpoint uses http:// (or is unset, defaulting to http://localhost:4318).
+// Returns false for https:// endpoints, allowing TLS to be used.
+func isInsecureEndpoint() bool {
+	endpoint := os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT")
+	if endpoint == "" {
+		endpoint = os.Getenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT")
+	}
+	if endpoint == "" {
+		return true // no endpoint configured, default is http://localhost:4318
+	}
+	return !strings.HasPrefix(endpoint, "https://")
+}
+```
+
+**Step 2: Update InitTracer to use conditional insecure**
+
+Replace the current `InitTracer` function body:
+
+```go
+func InitTracer() (func(), error) {
+	ctx := context.Background()
+
+	opts := []otlptracehttp.Option{
+		otlptracehttp.WithTimeout(60 * time.Second),
+	}
+	if isInsecureEndpoint() {
+		opts = append(opts, otlptracehttp.WithInsecure())
+	}
+
+	exporter, err := otlptracehttp.New(ctx, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("create exporter: %w", err)
+	}
+
+	shutdown, _, err := InitTracerWithExporter(exporter)
+	return shutdown, err
+}
+```
+
+**Step 3: Run the scheme detection tests**
+
+Run: `cd /Users/nadersoliman/projects/cc-trace && go test ./internal/tracer/ -run TestIsInsecureEndpoint -v`
+Expected: all 6 subtests PASS
+
+**Step 4: Run full test suite**
+
+Run: `cd /Users/nadersoliman/projects/cc-trace && go test ./... -v`
+Expected: ALL tests PASS
+
+**Step 5: Commit**
+
+```bash
+git add internal/tracer/tracer.go
+git commit -m "feat: support HTTPS endpoints by conditional WithInsecure" --author="Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Update documentation
+
+**Files:**
+- Modify: `CLAUDE.md`
+- Modify: `README.md`
+
+**Step 1: Update CLAUDE.md env var table**
+
+In the `OTEL_EXPORTER_OTLP_ENDPOINT` row, update the Purpose from:
+
+> Base OTLP endpoint. The HTTP exporter appends `/v1/traces` automatically. Shared with Claude Code's metrics/logs -- no separate traces endpoint needed.
+
+to:
+
+> Base OTLP endpoint. Supports both `http://` and `https://` schemes. The HTTP exporter appends `/v1/traces` automatically. Shared with Claude Code's metrics/logs -- no separate traces endpoint needed.
+
+Update the Note at the bottom of the env var section from:
+
+> **Note:** The hook previously used gRPC (`otlptracegrpc`, port 4317) with a separate `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`. It now uses HTTP/protobuf (`otlptracehttp`) to share the same `OTEL_EXPORTER_OTLP_ENDPOINT` as Claude Code's metrics and logs. Per the OTel spec, the HTTP exporter appends `/v1/traces` to the base endpoint automatically.
+
+to:
+
+> **Note:** The hook previously used gRPC (`otlptracegrpc`, port 4317) with a separate `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`. It now uses HTTP/protobuf (`otlptracehttp`) to share the same `OTEL_EXPORTER_OTLP_ENDPOINT` as Claude Code's metrics and logs. Per the OTel spec, the HTTP exporter appends `/v1/traces` to the base endpoint automatically. TLS is enabled automatically for `https://` endpoints; set `OTEL_EXPORTER_OTLP_HEADERS` for auth headers.
+
+**Step 2: Update README.md env var table**
+
+In the `OTEL_EXPORTER_OTLP_ENDPOINT` row, update the Purpose from:
+
+> OTLP/HTTP endpoint (appends `/v1/traces`)
+
+to:
+
+> OTLP endpoint — `http://` or `https://` (appends `/v1/traces`)
+
+Add `OTEL_EXPORTER_OTLP_HEADERS` to the env var table after `OTEL_RESOURCE_ATTRIBUTES`:
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `OTEL_EXPORTER_OTLP_HEADERS` | — | Comma-separated `key=value` headers for OTLP requests (e.g. `Authorization=Bearer xxx`). Read automatically by the OTel SDK |
+
+**Step 3: Commit**
+
+```bash
+git add CLAUDE.md README.md
+git commit -m "docs: document HTTPS endpoint support and auth headers" --author="Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Run full verification
+
+**Step 1: Run all tests**
+
+Run: `cd /Users/nadersoliman/projects/cc-trace && go test ./... -v -count=1`
+Expected: all tests PASS
+
+**Step 2: Build binary**
+
+Run: `cd /Users/nadersoliman/projects/cc-trace && go build -o /dev/null ./cmd/cc-trace/`
+Expected: success
+
+**Step 3: Run vet**
+
+Run: `cd /Users/nadersoliman/projects/cc-trace && go vet ./...`
+Expected: no issues

--- a/internal/tracer/tracer.go
+++ b/internal/tracer/tracer.go
@@ -33,6 +33,20 @@ func traceIDFromSession(sessionID string, epoch int) trace.TraceID {
 	return tid
 }
 
+// isInsecureEndpoint checks the configured OTLP endpoint scheme.
+// Returns true if the endpoint uses http:// (or is unset, defaulting to http://localhost:4318).
+// Returns false for https:// endpoints, allowing TLS to be used.
+func isInsecureEndpoint() bool {
+	endpoint := os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT")
+	if endpoint == "" {
+		endpoint = os.Getenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT")
+	}
+	if endpoint == "" {
+		return true // no endpoint configured, default is http://localhost:4318
+	}
+	return !strings.HasPrefix(endpoint, "https://")
+}
+
 // InitTracer sets up the OTel TracerProvider with OTLP HTTP exporter.
 //
 // All configuration is read from standard OTel environment variables:
@@ -42,10 +56,14 @@ func traceIDFromSession(sessionID string, epoch int) trace.TraceID {
 func InitTracer() (func(), error) {
 	ctx := context.Background()
 
-	exporter, err := otlptracehttp.New(ctx,
-		otlptracehttp.WithInsecure(),
-		otlptracehttp.WithTimeout(60*time.Second),
-	)
+	opts := []otlptracehttp.Option{
+		otlptracehttp.WithTimeout(60 * time.Second),
+	}
+	if isInsecureEndpoint() {
+		opts = append(opts, otlptracehttp.WithInsecure())
+	}
+
+	exporter, err := otlptracehttp.New(ctx, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("create exporter: %w", err)
 	}

--- a/internal/tracer/tracer_test.go
+++ b/internal/tracer/tracer_test.go
@@ -719,3 +719,29 @@ func TestExportSessionTrace_TraceparentSuppressesRotation(t *testing.T) {
 		t.Errorf("expected 0 Session spans (reusing existing), got %d", len(sessionSpans))
 	}
 }
+
+func TestIsInsecureEndpoint(t *testing.T) {
+	tests := []struct {
+		name     string
+		endpoint string
+		traces   string
+		want     bool
+	}{
+		{"http explicit", "http://localhost:4318", "", true},
+		{"https explicit", "https://otel.example.com", "", false},
+		{"empty defaults to insecure", "", "", true},
+		{"traces endpoint http", "", "http://localhost:4318/v1/traces", true},
+		{"traces endpoint https", "", "https://otel.example.com/v1/traces", false},
+		{"endpoint takes precedence", "https://otel.example.com", "http://localhost:4318/v1/traces", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", tt.endpoint)
+			t.Setenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", tt.traces)
+			if got := isInsecureEndpoint(); got != tt.want {
+				t.Errorf("isInsecureEndpoint() = %v, want %v (endpoint=%q traces=%q)", got, tt.want, tt.endpoint, tt.traces)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #25. Removes the hardcoded `WithInsecure()` from the OTLP HTTP exporter.

- Add `isInsecureEndpoint()` helper that detects the endpoint scheme from `OTEL_EXPORTER_OTLP_ENDPOINT` / `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`
- Only apply `WithInsecure()` for `http://` endpoints; `https://` endpoints use TLS automatically
- Document `OTEL_EXPORTER_OTLP_HEADERS` for auth headers with HTTPS endpoints

## Test Plan

- [x] `TestIsInsecureEndpoint` — 6 subtests covering http, https, empty, traces endpoint, precedence
- [x] All 44 existing tests pass
- [x] `go vet` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)