### PR TITLE
feat(debug): surface OTel export config + outcomes via CC_TRACE_DEBUG

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Add to your global Claude Code settings (`~/.claude/settings.json`):
 | `OTEL_SERVICE_NAME` | `unknown_service` | `service.name` resource attribute |
 | `OTEL_RESOURCE_ATTRIBUTES` | — | Comma-separated `key=value` pairs (e.g. `project.name=myapp`) |
 | `OTEL_EXPORTER_OTLP_HEADERS` | — | Comma-separated `key=value` headers for OTLP requests (e.g. `Authorization=Bearer xxx`). Read automatically by the OTel SDK |
-| `CC_TRACE_DEBUG` | `false` | Debug log to `~/.claude/state/cc_trace.log` |
+| `CC_TRACE_DEBUG` | `false` | Debug log to `~/.claude/state/cc_trace.log`. When enabled, logs resolved endpoint URL, transport mode (HTTP/HTTPS + insecure flag), presence and redacted values of all `OTEL_*` env vars, `CLAUDE_ENV_FILE` status, span export counts, Shutdown error/duration, and async OTel SDK transport errors. Sensitive values (keys matching `secret`, `token`, `bearer`, `authorization`, `cookie`, `api-key`, `client-secret`, or ending in `_KEY`) are redacted as `[REDACTED len=N]` |
 | `CC_TRACE_TIMING` | `false` | Phase-level timing logs to `~/.claude/state/cc_trace.log` |
 | `CC_TRACE_DUMP` | `false` | Dump raw hook payloads and transcripts to `/tmp/cc-trace/dumps/` |
 | `CC_TRACE_ROTATE` | `false` | Rotate trace ID per session segment. Each SessionStart (startup/resume/clear/compact) on an existing session creates a new trace, preventing long-lived sessions from outliving backend retention. Search by `session.id` attribute to find all segments. Ignored when `TRACEPARENT` is set -- the external trace owns the trace ID. |

--- a/docs/plans/2026-05-19-debug-export-config-design.md
+++ b/docs/plans/2026-05-19-debug-export-config-design.md
@@ -1,0 +1,136 @@
+# Debug Export Config + Secret Redaction Design
+
+**Issue:** #31
+**Origin:** [feat(debug): surface OTel export config + outcomes via CC_TRACE_DEBUG, with secret redaction](https://github.com/nadersoliman/cc-trace/issues/31)
+**Status:** draft
+**Depth:** Standard
+
+---
+
+## Problem Frame
+
+When cc-trace silently fails to export spans — wrong endpoint, missing auth headers, TLS failure, transport drop — the user sees `[INFO] Exported N turns in 0.0s` but no spans arrive at the backend. Diagnosing requires injecting an env-dump wrapper around the hook command and chasing layers manually. The existing `CC_TRACE_DEBUG=true` plumbing and `~/.claude/state/cc_trace.log` sink should surface enough to make every reasonable export failure self-evident from the log alone, without leaking auth secrets.
+
+## Scope
+
+- Add `[DEBUG]` log lines at three points: `InitTracer`, `ExportSessionTrace`, `Shutdown`
+- Set `otel.SetErrorHandler` to capture async SDK transport errors
+- Create a `redact` function to mask sensitive values by key pattern and value pattern
+- **No changes** to `[INFO]` level output
+- **No** log rotation work
+
+## Key Decisions
+
+### 1. Redact function location: `internal/logging/redact.go`
+
+The redact function is tightly coupled to the logging package and is only called when producing debug log lines. Placing it alongside `logging.go` keeps the dependency graph flat (no new package). The logging package is small (53 lines) and gains a clear second responsibility boundary.
+
+### 2. Shutdown closure signature: keep `func()`, log internally
+
+Today `InitTracer` returns `(func(), error)` and the shutdown closure discards `tp.Shutdown()` errors. Changing the signature to `func() error` would break `InitTracerWithExporter`, `setupTestTracer`, and `handleStop`.
+
+Instead: capture and log the error + duration inside the closure itself, guarded by `sync.Once` to prevent duplicate logs from the `defer shutdown()` safety net in `handleStop`.
+
+```
+shutdown := func() {
+    once.Do(func() {
+        start := time.Now()
+        err := tp.Shutdown(context.Background())
+        logging.Debug(fmt.Sprintf("Shutdown: duration=%dms err=%v", ...))
+    })
+}
+```
+
+This satisfies the issue's "surface this" requirement without an API change.
+
+### 3. otel.SetErrorHandler placement: `InitTracerWithExporter`
+
+Placed in `InitTracerWithExporter` (not just `InitTracer`) so both production and test paths register the handler. The handler routes errors to `logging.Debug`:
+
+```
+otel.SetErrorHandler(otel.ErrorHandlerFunc(func(err error) {
+    logging.Debug(fmt.Sprintf("OTel SDK error: %v", err))
+}))
+```
+
+### 4. CLAUDE_ENV_FILE "sourced" heuristic
+
+cc-trace is a Go binary invoked by Claude Code — it cannot know whether Claude Code actually sourced the env file. The heuristic: if `CLAUDE_ENV_FILE` is set and the file exists, report `sourced=true` (Claude Code sets this var and sources the file as part of hook invocation). If the file doesn't exist, report `sourced=false`.
+
+### 5. Span count: computed from input data
+
+Count spans from the structured input before export rather than from the OTel SDK internals:
+- 1 session span (if created this invocation)
+- N turn spans
+- N LLM spans (turns with Model != "")
+- sum of tool spans per turn
+- Subagent spans are nested and harder to pre-count; omit from the count or add a counter in `createTurnSpans`
+
+This is approximate but sufficient for debug output.
+
+### 6. Header env var parsing
+
+`OTEL_EXPORTER_OTLP_HEADERS` uses format `key1=val1,key2=val2`. Parse into key-value pairs, log keys verbatim, redact each value individually. A dedicated `RedactHeadersEnv` function handles this format.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `internal/logging/redact.go` (new) | `Redact(value, key)` and `RedactHeadersEnv(raw)` functions |
+| `internal/logging/redact_test.go` (new) | Unit tests against all cases from the issue |
+| `internal/tracer/tracer.go` | Debug logging in InitTracer, Shutdown error/duration logging, otel.SetErrorHandler |
+| `internal/tracer/tracer_test.go` | Tests for debug logging behavior |
+| `cmd/cc-trace/main.go` | No changes needed (shutdown closure handles logging internally) |
+| `README.md` | Document CC_TRACE_DEBUG richer output and redaction patterns |
+
+## Redaction Rules (from issue)
+
+**Key-based** (case-insensitive substring): `secret`, `token`, `password`, `bearer`, `authorization`, `cookie`, `api-key`, `apikey`, `client-id`, `client-secret`, keys ending in `_KEY`
+
+**Value-based** (regardless of key): JWT pattern (`eyJ` prefix with two `.` separators), hex string >= 32 chars, `Bearer ` prefix
+
+**Output formats:**
+- Sensitive: `[REDACTED len=N]`
+- Non-sensitive, len > 16: `first8 ... last4 (len=N)`
+- Non-sensitive, len <= 16: verbatim
+
+## Test Scenarios
+
+### Redact function
+1. `Authorization: Bearer eyJhbGc...` -> `[REDACTED len=200]` (key match)
+2. `CF-Access-Client-Secret: 17da284b...` -> `[REDACTED len=64]` (key match)
+3. `OTEL_EXPORTER_OTLP_ENDPOINT: https://otel.example.com` -> verbatim (not sensitive)
+4. `OTEL_SERVICE_NAME: claude-code-default` -> verbatim (not sensitive, len=19 > 16 so truncated)
+5. Non-sensitive key with JWT value -> `[REDACTED len=N]` (value pattern match)
+6. Non-sensitive key with long hex value -> `[REDACTED len=N]` (value pattern match)
+7. Non-sensitive key with `Bearer xyz` value -> `[REDACTED len=N]` (value pattern match)
+8. Key ending in `_KEY` -> `[REDACTED len=N]`
+9. Empty value -> verbatim
+10. Short non-sensitive value (len <= 16) -> verbatim
+
+### RedactHeadersEnv
+1. `CF-Access-Client-Id=foo,CF-Access-Client-Secret=bar` -> keys visible, values redacted
+2. Empty string -> "(absent)"
+3. Single key-value pair -> correct parse
+4. Malformed (no `=`) -> handled gracefully
+
+### InitTracer debug logging
+1. With all env vars set -> all logged with correct present/absent status
+2. With no env vars set -> all show "(absent)", endpoint shows default
+3. With HTTPS endpoint -> `insecure=false (scheme=https)`
+4. With HTTP endpoint -> `insecure=true (scheme=http)`
+5. With CLAUDE_ENV_FILE set, file exists -> `file exists=true, sourced=true`
+6. With CLAUDE_ENV_FILE set, file missing -> `file exists=false, sourced=false`
+
+### Shutdown logging
+1. Successful shutdown -> `duration=Nms err=<nil>`
+2. Double shutdown call (defer + explicit) -> logged only once (sync.Once)
+
+### otel.SetErrorHandler
+1. SDK error handler is registered and routes to logging.Debug
+
+## Risk
+
+- **Low:** All new code is gated behind `CC_TRACE_DEBUG=true` via existing `logging.Debug()`. Zero overhead when debug is off.
+- **Low:** `sync.Once` in shutdown closure prevents double-log but also means the deferred safety-net call won't log if the explicit call already ran. Acceptable — the first call's log is the one that matters.
+- **Medium:** The `otel.SetErrorHandler` is global (per the OTel SDK). In tests using `InitTracerWithExporter`, this could interfere if tests run in parallel. Mitigated by the fact that tracer tests already use a global TracerProvider and are not parallelized.

--- a/docs/plans/2026-05-19-debug-export-config-implementation.md
+++ b/docs/plans/2026-05-19-debug-export-config-implementation.md
@@ -1,0 +1,311 @@
+# Debug Export Config + Secret Redaction Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** When `CC_TRACE_DEBUG=true`, log enough at InitTracer, ExportSessionTrace, and Shutdown to make every reasonable export failure self-evident from `cc_trace.log` alone, without leaking auth secrets.
+
+**Architecture:** New `Redact` / `RedactHeadersEnv` functions in `internal/logging/redact.go`. Debug logging added to `InitTracer` (env var dump), `ExportSessionTrace` (span count), and Shutdown (error + duration). `otel.SetErrorHandler` routes async SDK errors to `logging.Debug`. Shutdown closure logs internally via `sync.Once`.
+
+**Tech Stack:** Go, OTel SDK v1.40.0, `internal/logging` package
+
+---
+
+### Task 1: Create redact function and tests
+
+**Files:**
+- Create: `internal/logging/redact.go`
+- Create: `internal/logging/redact_test.go`
+
+**Step 1: Write `internal/logging/redact.go`**
+
+```go
+package logging
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+var sensitiveKeyPatterns = []string{
+	"secret", "token", "password", "bearer", "authorization",
+	"cookie", "api-key", "apikey", "client-id", "client-secret",
+}
+
+var jwtPattern = regexp.MustCompile(`^eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$`)
+var longHexPattern = regexp.MustCompile(`^[0-9a-fA-F]{32,}$`)
+
+func Redact(value, key string) string {
+	if value == "" {
+		return value
+	}
+	if isSensitiveKey(key) || isSensitiveValue(value) {
+		return fmt.Sprintf("[REDACTED len=%d]", len(value))
+	}
+	if len(value) > 16 {
+		return fmt.Sprintf("%s ... %s (len=%d)", value[:8], value[len(value)-4:], len(value))
+	}
+	return value
+}
+
+func RedactHeadersEnv(raw string) string {
+	if raw == "" {
+		return "(absent)"
+	}
+	pairs := strings.Split(raw, ",")
+	var parts []string
+	for _, pair := range pairs {
+		idx := strings.Index(pair, "=")
+		if idx < 0 {
+			parts = append(parts, pair)
+			continue
+		}
+		key := pair[:idx]
+		val := pair[idx+1:]
+		parts = append(parts, fmt.Sprintf("%s=%s", key, Redact(val, key)))
+	}
+	return fmt.Sprintf("[%d keys: %s]", len(pairs), strings.Join(parts, ", "))
+}
+
+func isSensitiveKey(key string) bool {
+	lower := strings.ToLower(key)
+	for _, p := range sensitiveKeyPatterns {
+		if strings.Contains(lower, p) {
+			return true
+		}
+	}
+	return strings.HasSuffix(lower, "_key")
+}
+
+func isSensitiveValue(value string) bool {
+	if strings.HasPrefix(value, "Bearer ") {
+		return true
+	}
+	if jwtPattern.MatchString(value) {
+		return true
+	}
+	return longHexPattern.MatchString(value)
+}
+```
+
+**Step 2: Write `internal/logging/redact_test.go`**
+
+Test cases from the issue:
+- `Authorization` key with `Bearer eyJhbGc...` value -> `[REDACTED len=N]`
+- `CF-Access-Client-Secret` key with hex value -> `[REDACTED len=N]`
+- `OTEL_EXPORTER_OTLP_ENDPOINT` key with URL -> verbatim or truncated (len > 16)
+- `OTEL_SERVICE_NAME` key with `claude-code-default` -> truncated (len=19)
+- Non-sensitive key with JWT value -> `[REDACTED len=N]` (value pattern)
+- Non-sensitive key with `Bearer xxx` value -> `[REDACTED len=N]` (value pattern)
+- Key ending in `_KEY` -> `[REDACTED len=N]`
+- Empty value -> empty string
+- Short non-sensitive value -> verbatim
+- `RedactHeadersEnv` with `CF-Access-Client-Id=foo,CF-Access-Client-Secret=bar`
+- `RedactHeadersEnv` with empty string -> `"(absent)"`
+- `RedactHeadersEnv` with malformed pair (no `=`)
+
+**Step 3: Run tests**
+
+Run: `cd /Users/nadersoliman/projects/cc-trace && go test ./internal/logging/ -run TestRedact -v`
+Expected: PASS
+
+**Step 4: Commit**
+
+```bash
+git add internal/logging/redact.go internal/logging/redact_test.go
+git commit -m "feat(logging): add Redact and RedactHeadersEnv for secret-safe debug output" --author="Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Add debug logging to InitTracer
+
+**Files:**
+- Modify: `internal/tracer/tracer.go`
+
+**Step 1: Add `logExportConfig` function**
+
+Add a new function in `tracer.go` that logs each OTel env var with redaction. Called from `InitTracer` after the exporter is created.
+
+Env vars to log (from issue):
+- `OTEL_EXPORTER_OTLP_ENDPOINT`
+- `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`
+- `OTEL_EXPORTER_OTLP_HEADERS`
+- `OTEL_EXPORTER_OTLP_TRACES_HEADERS`
+- `OTEL_EXPORTER_OTLP_PROTOCOL`
+- `OTEL_RESOURCE_ATTRIBUTES`
+- `OTEL_SERVICE_NAME`
+- `OTEL_EXPORTER_OTLP_CERTIFICATE`
+- `OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE`
+- `OTEL_EXPORTER_OTLP_CLIENT_KEY`
+- `CLAUDE_ENV_FILE`
+
+Log format examples:
+```
+InitTracer: endpoint=https://otel.example.com/v1/traces insecure=false (scheme=https)
+env: OTEL_EXPORTER_OTLP_ENDPOINT=https://o ... .com (len=24, present)
+env: OTEL_EXPORTER_OTLP_HEADERS=[2 keys: CF-Access-Client-Id=[REDACTED len=38], CF-Access-Client-Secret=[REDACTED len=64]]
+env: CLAUDE_ENV_FILE=/Users ... .sh (len=104, present, file exists=true, sourced=true)
+```
+
+For header env vars (`OTEL_EXPORTER_OTLP_HEADERS`, `OTEL_EXPORTER_OTLP_TRACES_HEADERS`), use `logging.RedactHeadersEnv`.
+
+For `CLAUDE_ENV_FILE`: check `os.Stat` for file existence. Report `sourced=true` if file exists (Claude Code sources files it points to via this var), `sourced=false` otherwise.
+
+For all other env vars: use `logging.Redact(value, key)` and report `present`/`absent`.
+
+**Step 2: Call `logExportConfig` from `InitTracer`**
+
+Add the call between the `isInsecureEndpoint()` check and the exporter creation, so the resolved endpoint + insecure state is logged first, then each env var.
+
+**Step 3: Run tests**
+
+Run: `cd /Users/nadersoliman/projects/cc-trace && go test ./internal/tracer/ -v`
+Expected: PASS (existing tests don't enable debug logging)
+
+**Step 4: Commit**
+
+```bash
+git add internal/tracer/tracer.go
+git commit -m "feat(tracer): log OTel export config at InitTracer when debug enabled" --author="Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Add otel.SetErrorHandler and Shutdown logging
+
+**Files:**
+- Modify: `internal/tracer/tracer.go`
+
+**Step 1: Register `otel.SetErrorHandler` in `InitTracerWithExporter`**
+
+Add before `otel.SetTracerProvider(tp)`:
+
+```go
+otel.SetErrorHandler(otel.ErrorHandlerFunc(func(err error) {
+    logging.Debug(fmt.Sprintf("OTel SDK error (via otel.SetErrorHandler): %v", err))
+}))
+```
+
+Import `otel.ErrorHandlerFunc` — this is the function adapter type in `go.opentelemetry.io/otel` that implements the `ErrorHandler` interface.
+
+**Step 2: Add Shutdown error + duration logging**
+
+Change the shutdown closure in `InitTracerWithExporter` to:
+
+```go
+var once sync.Once
+shutdown := func() {
+    once.Do(func() {
+        start := time.Now()
+        err := tp.Shutdown(context.Background())
+        dur := time.Since(start)
+        logging.Debug(fmt.Sprintf("Shutdown: duration=%dms err=%v", dur.Milliseconds(), err))
+    })
+}
+```
+
+Add `"sync"` to imports.
+
+**Step 3: Run tests**
+
+Run: `cd /Users/nadersoliman/projects/cc-trace && go test ./... -v`
+Expected: ALL PASS. The `setupTestTracer` helper calls `InitTracerWithExporter` and returns `shutdown` — the sync.Once guard ensures clean behavior.
+
+**Step 4: Commit**
+
+```bash
+git add internal/tracer/tracer.go
+git commit -m "feat(tracer): log Shutdown error/duration and register OTel SDK error handler" --author="Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Add ExportSessionTrace debug logging
+
+**Files:**
+- Modify: `internal/tracer/tracer.go`
+
+**Step 1: Add span count computation**
+
+Before the `createTurnSpans` call in `ExportSessionTrace`, compute the expected span count:
+
+```go
+spanCount := 0
+if sessionSpan != nil {
+    spanCount++ // session span created this invocation
+}
+for _, turn := range turns {
+    spanCount++ // turn span
+    if turn.Model != "" {
+        spanCount++ // LLM span
+    }
+    spanCount += len(turn.ToolCalls) // tool spans
+}
+```
+
+**Step 2: Replace the existing debug line**
+
+Change the existing `logging.Debug(fmt.Sprintf("Exported %d turns for session %s", ...))` to:
+
+```go
+logging.Debug(fmt.Sprintf("ExportSessionTrace: spans=%d (session=%s, turns=%d)", spanCount, truncate(sessionID, 8), len(turns)))
+```
+
+**Step 3: Run tests**
+
+Run: `cd /Users/nadersoliman/projects/cc-trace && go test ./internal/tracer/ -v`
+Expected: PASS
+
+**Step 4: Commit**
+
+```bash
+git add internal/tracer/tracer.go
+git commit -m "feat(tracer): log span count at ExportSessionTrace when debug enabled" --author="Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Update documentation
+
+**Files:**
+- Modify: `README.md`
+
+**Step 1: Update CC_TRACE_DEBUG description**
+
+In the environment variables table, expand the `CC_TRACE_DEBUG` description to mention the richer debug output: resolved endpoint, env var presence, header keys (redacted values), transport mode, Shutdown error/duration, and OTel SDK async errors.
+
+**Step 2: Add redaction note**
+
+Add a brief note that values matching sensitive patterns (`secret`, `token`, `bearer`, `authorization`, `cookie`, `api-key`, `client-secret`, keys ending in `_KEY`) are redacted as `[REDACTED len=N]` in debug output.
+
+**Step 3: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: document CC_TRACE_DEBUG richer output and secret redaction" --author="Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: Run full verification
+
+**Step 1: Run all tests**
+
+Run: `cd /Users/nadersoliman/projects/cc-trace && go test ./... -v -count=1`
+Expected: all tests PASS
+
+**Step 2: Build binary**
+
+Run: `cd /Users/nadersoliman/projects/cc-trace && go build -o /dev/null ./cmd/cc-trace/`
+Expected: success
+
+**Step 3: Run vet**
+
+Run: `cd /Users/nadersoliman/projects/cc-trace && go vet ./...`
+Expected: no issues
+
+**Step 4: Run gofmt check**
+
+Run: `cd /Users/nadersoliman/projects/cc-trace && gofmt -s -l .`
+Expected: no output (all files formatted)

--- a/internal/logging/redact.go
+++ b/internal/logging/redact.go
@@ -1,0 +1,67 @@
+package logging
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+var sensitiveKeyPatterns = []string{
+	"secret", "token", "password", "bearer", "authorization",
+	"cookie", "api-key", "apikey", "client-id", "client-secret",
+}
+
+var jwtPattern = regexp.MustCompile(`^eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$`)
+var longHexPattern = regexp.MustCompile(`^[0-9a-fA-F]{32,}$`)
+
+func Redact(value, key string) string {
+	if value == "" {
+		return value
+	}
+	if isSensitiveKey(key) || isSensitiveValue(value) {
+		return fmt.Sprintf("[REDACTED len=%d]", len(value))
+	}
+	if len(value) > 16 {
+		return fmt.Sprintf("%s ... %s (len=%d)", value[:8], value[len(value)-4:], len(value))
+	}
+	return value
+}
+
+func RedactHeadersEnv(raw string) string {
+	if raw == "" {
+		return "(absent)"
+	}
+	pairs := strings.Split(raw, ",")
+	var parts []string
+	for _, pair := range pairs {
+		idx := strings.Index(pair, "=")
+		if idx < 0 {
+			parts = append(parts, pair)
+			continue
+		}
+		key := pair[:idx]
+		val := pair[idx+1:]
+		parts = append(parts, fmt.Sprintf("%s=%s", key, Redact(val, key)))
+	}
+	return fmt.Sprintf("[%d keys: %s]", len(pairs), strings.Join(parts, ", "))
+}
+
+func isSensitiveKey(key string) bool {
+	lower := strings.ToLower(key)
+	for _, p := range sensitiveKeyPatterns {
+		if strings.Contains(lower, p) {
+			return true
+		}
+	}
+	return strings.HasSuffix(lower, "_key")
+}
+
+func isSensitiveValue(value string) bool {
+	if strings.HasPrefix(value, "Bearer ") {
+		return true
+	}
+	if jwtPattern.MatchString(value) {
+		return true
+	}
+	return longHexPattern.MatchString(value)
+}

--- a/internal/logging/redact_test.go
+++ b/internal/logging/redact_test.go
@@ -1,0 +1,98 @@
+package logging
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRedact_SensitiveKeys(t *testing.T) {
+	tests := []struct {
+		name  string
+		key   string
+		value string
+		want  string
+	}{
+		{"authorization header", "Authorization", "Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.abc123signature", "[REDACTED len=71]"},
+		{"client-secret", "CF-Access-Client-Secret", "17da284b1e2f4a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b", "[REDACTED len=64]"},
+		{"token key", "X-Auth-Token", "mytoken123", "[REDACTED len=10]"},
+		{"password key", "DB_PASSWORD", "hunter2", "[REDACTED len=7]"},
+		{"cookie key", "Session-Cookie", "abc123", "[REDACTED len=6]"},
+		{"apikey key", "X-ApiKey", "key12345", "[REDACTED len=8]"},
+		{"api-key key", "X-Api-Key", "key12345", "[REDACTED len=8]"},
+		{"client-id key", "CF-Access-Client-Id", "some-client-id-value-here-long", "[REDACTED len=30]"},
+		{"key ending in _KEY", "OTEL_EXPORTER_OTLP_CLIENT_KEY", "/path/to/client.key", "[REDACTED len=19]"},
+		{"case insensitive", "x-authorization", "val", "[REDACTED len=3]"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Redact(tt.value, tt.key)
+			if got != tt.want {
+				t.Errorf("Redact(%q, %q) = %q, want %q", tt.value, tt.key, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRedact_SensitiveValues(t *testing.T) {
+	tests := []struct {
+		name  string
+		key   string
+		value string
+	}{
+		{"JWT value", "X-Custom", "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.abc123signature"},
+		{"Bearer prefix value", "X-Custom", "Bearer some-token-here"},
+		{"long hex value", "X-Custom", "17da284b1e2f4a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Redact(tt.value, tt.key)
+			if !strings.HasPrefix(got, "[REDACTED len=") {
+				t.Errorf("Redact(%q, %q) = %q, want [REDACTED ...]", tt.value, tt.key, got)
+			}
+		})
+	}
+}
+
+func TestRedact_NonSensitive(t *testing.T) {
+	tests := []struct {
+		name  string
+		key   string
+		value string
+		want  string
+	}{
+		{"empty value", "OTEL_SERVICE_NAME", "", ""},
+		{"short value", "OTEL_SERVICE_NAME", "my-service", "my-service"},
+		{"exactly 16 chars", "OTEL_SERVICE_NAME", "1234567890123456", "1234567890123456"},
+		{"long URL", "OTEL_EXPORTER_OTLP_ENDPOINT", "https://otel.example.com", "https:// ... .com (len=24)"},
+		{"long service name", "OTEL_SERVICE_NAME", "claude-code-default", "claude-c ... ault (len=19)"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Redact(tt.value, tt.key)
+			if got != tt.want {
+				t.Errorf("Redact(%q, %q) = %q, want %q", tt.value, tt.key, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRedactHeadersEnv(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{"absent", "", "(absent)"},
+		{"single non-sensitive pair", "Content-Type=application/json", "[1 keys: Content-Type=application/json]"},
+		{"two sensitive pairs", "CF-Access-Client-Id=abc123,CF-Access-Client-Secret=secret456", "[2 keys: CF-Access-Client-Id=[REDACTED len=6], CF-Access-Client-Secret=[REDACTED len=9]]"},
+		{"malformed no equals", "garbage", "[1 keys: garbage]"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := RedactHeadersEnv(tt.raw)
+			if got != tt.want {
+				t.Errorf("RedactHeadersEnv(%q) = %q, want %q", tt.raw, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/tracer/tracer.go
+++ b/internal/tracer/tracer.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	"cc-trace/internal/hook"
@@ -47,6 +48,69 @@ func isInsecureEndpoint() bool {
 	return !strings.HasPrefix(endpoint, "https://")
 }
 
+func logExportConfig() {
+	endpoint := os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT")
+	tracesEndpoint := os.Getenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT")
+
+	resolvedEndpoint := endpoint
+	if resolvedEndpoint == "" {
+		resolvedEndpoint = tracesEndpoint
+	}
+
+	insecure := isInsecureEndpoint()
+	if resolvedEndpoint == "" {
+		logging.Debug(fmt.Sprintf("InitTracer: endpoint=http://localhost:4318/v1/traces insecure=true (scheme=http, default — no OTEL_EXPORTER_OTLP_ENDPOINT set)"))
+	} else {
+		scheme := "http"
+		if strings.HasPrefix(resolvedEndpoint, "https://") {
+			scheme = "https"
+		}
+		logging.Debug(fmt.Sprintf("InitTracer: endpoint=%s/v1/traces insecure=%v (scheme=%s)", resolvedEndpoint, insecure, scheme))
+	}
+
+	envVars := []string{
+		"OTEL_EXPORTER_OTLP_ENDPOINT",
+		"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+		"OTEL_EXPORTER_OTLP_PROTOCOL",
+		"OTEL_RESOURCE_ATTRIBUTES",
+		"OTEL_SERVICE_NAME",
+		"OTEL_EXPORTER_OTLP_CERTIFICATE",
+		"OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE",
+		"OTEL_EXPORTER_OTLP_CLIENT_KEY",
+	}
+	for _, name := range envVars {
+		val := os.Getenv(name)
+		if val == "" {
+			logging.Debug(fmt.Sprintf("env: %s=(absent)", name))
+		} else {
+			logging.Debug(fmt.Sprintf("env: %s=%s (len=%d, present)", name, logging.Redact(val, name), len(val)))
+		}
+	}
+
+	headerVars := []string{
+		"OTEL_EXPORTER_OTLP_HEADERS",
+		"OTEL_EXPORTER_OTLP_TRACES_HEADERS",
+	}
+	for _, name := range headerVars {
+		val := os.Getenv(name)
+		if val == "" {
+			logging.Debug(fmt.Sprintf("env: %s=(absent)", name))
+		} else {
+			logging.Debug(fmt.Sprintf("env: %s=%s", name, logging.RedactHeadersEnv(val)))
+		}
+	}
+
+	envFile := os.Getenv("CLAUDE_ENV_FILE")
+	if envFile == "" {
+		logging.Debug("env: CLAUDE_ENV_FILE=(absent)")
+	} else {
+		_, err := os.Stat(envFile)
+		exists := err == nil
+		sourced := exists
+		logging.Debug(fmt.Sprintf("env: CLAUDE_ENV_FILE=%s (len=%d, present, file exists=%v, sourced=%v)", logging.Redact(envFile, "CLAUDE_ENV_FILE"), len(envFile), exists, sourced))
+	}
+}
+
 // InitTracer sets up the OTel TracerProvider with OTLP HTTP exporter.
 //
 // All configuration is read from standard OTel environment variables:
@@ -54,6 +118,8 @@ func isInsecureEndpoint() bool {
 //   - OTEL_SERVICE_NAME (default: unknown_service)
 //   - OTEL_RESOURCE_ATTRIBUTES (default: none)
 func InitTracer() (func(), error) {
+	logExportConfig()
+
 	ctx := context.Background()
 
 	opts := []otlptracehttp.Option{
@@ -96,10 +162,18 @@ func InitTracerWithExporter(exporter sdktrace.SpanExporter) (func(), func(), err
 		sdktrace.WithSpanProcessor(bsp),
 		sdktrace.WithResource(res),
 	)
+	otel.SetErrorHandler(otel.ErrorHandlerFunc(func(err error) {
+		logging.Debug(fmt.Sprintf("OTel SDK error (via otel.SetErrorHandler): %v", err))
+	}))
 	otel.SetTracerProvider(tp)
 
+	var once sync.Once
 	shutdown := func() {
-		_ = tp.Shutdown(context.Background())
+		once.Do(func() {
+			start := time.Now()
+			err := tp.Shutdown(context.Background())
+			logging.Debug(fmt.Sprintf("Shutdown: duration=%dms err=%v", time.Since(start).Milliseconds(), err))
+		})
 	}
 	flush := func() {
 		_ = tp.ForceFlush(context.Background())
@@ -184,7 +258,19 @@ func ExportSessionTrace(sessionID string, turns []hook.Turn, toolSpanData []hook
 	if sessionSpan != nil {
 		sessionSpan.End(trace.WithTimestamp(sessionEnd))
 	}
-	logging.Debug(fmt.Sprintf("Exported %d turns for session %s", len(turns), truncate(sessionID, 12)))
+
+	spanCount := 0
+	if sessionSpan != nil {
+		spanCount++
+	}
+	for _, turn := range turns {
+		spanCount++
+		if turn.Model != "" {
+			spanCount++
+		}
+		spanCount += len(turn.ToolCalls)
+	}
+	logging.Debug(fmt.Sprintf("ExportSessionTrace: spans=%d (session=%s, turns=%d)", spanCount, truncate(sessionID, 8), len(turns)))
 }
 
 // parseTraceparent reads TRACEPARENT from the environment and returns a context

--- a/internal/tracer/tracer_test.go
+++ b/internal/tracer/tracer_test.go
@@ -1,6 +1,8 @@
 package tracer
 
 import (
+	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -9,6 +11,7 @@ import (
 	"cc-trace/internal/hook"
 	"cc-trace/internal/logging"
 
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 )
 
@@ -717,6 +720,262 @@ func TestExportSessionTrace_TraceparentSuppressesRotation(t *testing.T) {
 	sessionSpans := findSpans(spans2, "Session")
 	if len(sessionSpans) != 0 {
 		t.Errorf("expected 0 Session spans (reusing existing), got %d", len(sessionSpans))
+	}
+}
+
+func TestLogExportConfig(t *testing.T) {
+	logFile := filepath.Join(t.TempDir(), "test.log")
+	logging.Init(logFile, true) // debug=true
+
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "https://otel.example.com")
+	t.Setenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "")
+	t.Setenv("OTEL_EXPORTER_OTLP_HEADERS", "CF-Access-Client-Id=abc123,CF-Access-Client-Secret=supersecretvalue")
+	t.Setenv("OTEL_EXPORTER_OTLP_TRACES_HEADERS", "")
+	t.Setenv("OTEL_EXPORTER_OTLP_PROTOCOL", "")
+	t.Setenv("OTEL_RESOURCE_ATTRIBUTES", "project.name=test")
+	t.Setenv("OTEL_SERVICE_NAME", "test-service")
+	t.Setenv("OTEL_EXPORTER_OTLP_CERTIFICATE", "")
+	t.Setenv("OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE", "")
+	t.Setenv("OTEL_EXPORTER_OTLP_CLIENT_KEY", "")
+	t.Setenv("CLAUDE_ENV_FILE", "")
+
+	logExportConfig()
+
+	data, err := os.ReadFile(logFile)
+	if err != nil {
+		t.Fatalf("failed to read log file: %v", err)
+	}
+	log := string(data)
+
+	// Should log endpoint and insecure state.
+	if !strings.Contains(log, "endpoint=https://otel.example.com/v1/traces") {
+		t.Errorf("log missing endpoint line, got:\n%s", log)
+	}
+	if !strings.Contains(log, "insecure=false") {
+		t.Errorf("log missing insecure=false, got:\n%s", log)
+	}
+
+	// Should log env vars with present/absent.
+	if !strings.Contains(log, "OTEL_EXPORTER_OTLP_ENDPOINT=") && !strings.Contains(log, "present") {
+		t.Errorf("log missing OTEL_EXPORTER_OTLP_ENDPOINT, got:\n%s", log)
+	}
+
+	// Headers should show keys but redact sensitive values.
+	if !strings.Contains(log, "OTEL_EXPORTER_OTLP_HEADERS=") {
+		t.Errorf("log missing OTEL_EXPORTER_OTLP_HEADERS, got:\n%s", log)
+	}
+	if !strings.Contains(log, "CF-Access-Client-Secret=[REDACTED") {
+		t.Errorf("log should redact CF-Access-Client-Secret, got:\n%s", log)
+	}
+	if strings.Contains(log, "supersecretvalue") {
+		t.Errorf("log should NOT contain raw secret value, got:\n%s", log)
+	}
+
+	// Absent vars should show (absent).
+	if !strings.Contains(log, "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=(absent)") {
+		t.Errorf("log missing absent TRACES_ENDPOINT, got:\n%s", log)
+	}
+}
+
+func TestLogExportConfig_DefaultEndpoint(t *testing.T) {
+	logFile := filepath.Join(t.TempDir(), "test.log")
+	logging.Init(logFile, true)
+
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "")
+	t.Setenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "")
+	t.Setenv("OTEL_EXPORTER_OTLP_HEADERS", "")
+	t.Setenv("OTEL_EXPORTER_OTLP_TRACES_HEADERS", "")
+	t.Setenv("OTEL_EXPORTER_OTLP_PROTOCOL", "")
+	t.Setenv("OTEL_RESOURCE_ATTRIBUTES", "")
+	t.Setenv("OTEL_SERVICE_NAME", "")
+	t.Setenv("OTEL_EXPORTER_OTLP_CERTIFICATE", "")
+	t.Setenv("OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE", "")
+	t.Setenv("OTEL_EXPORTER_OTLP_CLIENT_KEY", "")
+	t.Setenv("CLAUDE_ENV_FILE", "")
+
+	logExportConfig()
+
+	data, err := os.ReadFile(logFile)
+	if err != nil {
+		t.Fatalf("failed to read log file: %v", err)
+	}
+	log := string(data)
+
+	if !strings.Contains(log, "insecure=true") {
+		t.Errorf("log should show insecure=true for default endpoint, got:\n%s", log)
+	}
+	if !strings.Contains(log, "default") {
+		t.Errorf("log should indicate default endpoint, got:\n%s", log)
+	}
+}
+
+func TestLogExportConfig_ClaudeEnvFile(t *testing.T) {
+	dir := t.TempDir()
+	logFile := filepath.Join(dir, "test.log")
+	logging.Init(logFile, true)
+
+	// Create a fake env file.
+	envFile := filepath.Join(dir, "env.sh")
+	os.WriteFile(envFile, []byte("export FOO=bar"), 0o644)
+
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "")
+	t.Setenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "")
+	t.Setenv("OTEL_EXPORTER_OTLP_HEADERS", "")
+	t.Setenv("OTEL_EXPORTER_OTLP_TRACES_HEADERS", "")
+	t.Setenv("OTEL_EXPORTER_OTLP_PROTOCOL", "")
+	t.Setenv("OTEL_RESOURCE_ATTRIBUTES", "")
+	t.Setenv("OTEL_SERVICE_NAME", "")
+	t.Setenv("OTEL_EXPORTER_OTLP_CERTIFICATE", "")
+	t.Setenv("OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE", "")
+	t.Setenv("OTEL_EXPORTER_OTLP_CLIENT_KEY", "")
+	t.Setenv("CLAUDE_ENV_FILE", envFile)
+
+	logExportConfig()
+
+	data, err := os.ReadFile(logFile)
+	if err != nil {
+		t.Fatalf("failed to read log file: %v", err)
+	}
+	log := string(data)
+
+	if !strings.Contains(log, "CLAUDE_ENV_FILE=") {
+		t.Errorf("log missing CLAUDE_ENV_FILE line, got:\n%s", log)
+	}
+	if !strings.Contains(log, "file exists=true") {
+		t.Errorf("log should show file exists=true, got:\n%s", log)
+	}
+}
+
+func TestShutdownLogging(t *testing.T) {
+	logFile := filepath.Join(t.TempDir(), "test.log")
+	logging.Init(logFile, true) // debug=true
+
+	exporter := tracetest.NewInMemoryExporter()
+	shutdown, _, err := InitTracerWithExporter(exporter)
+	if err != nil {
+		t.Fatalf("InitTracerWithExporter: %v", err)
+	}
+
+	// Call shutdown — should log duration and error.
+	shutdown()
+
+	data, err := os.ReadFile(logFile)
+	if err != nil {
+		t.Fatalf("failed to read log file: %v", err)
+	}
+	log := string(data)
+
+	if !strings.Contains(log, "Shutdown: duration=") {
+		t.Errorf("log missing Shutdown duration line, got:\n%s", log)
+	}
+	if !strings.Contains(log, "err=<nil>") {
+		t.Errorf("log missing err=<nil>, got:\n%s", log)
+	}
+}
+
+func TestShutdownLogging_OnlyOnce(t *testing.T) {
+	logFile := filepath.Join(t.TempDir(), "test.log")
+	logging.Init(logFile, true)
+
+	exporter := tracetest.NewInMemoryExporter()
+	shutdown, _, err := InitTracerWithExporter(exporter)
+	if err != nil {
+		t.Fatalf("InitTracerWithExporter: %v", err)
+	}
+
+	// Call shutdown twice (simulates defer + explicit in handleStop).
+	shutdown()
+	shutdown()
+
+	data, err := os.ReadFile(logFile)
+	if err != nil {
+		t.Fatalf("failed to read log file: %v", err)
+	}
+	log := string(data)
+
+	// Should only appear once.
+	count := strings.Count(log, "Shutdown: duration=")
+	if count != 1 {
+		t.Errorf("expected exactly 1 Shutdown log line, got %d:\n%s", count, log)
+	}
+}
+
+func TestOtelErrorHandler(t *testing.T) {
+	logFile := filepath.Join(t.TempDir(), "test.log")
+	logging.Init(logFile, true)
+
+	exporter := tracetest.NewInMemoryExporter()
+	shutdown, _, err := InitTracerWithExporter(exporter)
+	if err != nil {
+		t.Fatalf("InitTracerWithExporter: %v", err)
+	}
+	defer shutdown()
+
+	// Trigger the error handler manually via the global otel package.
+	otel.Handle(fmt.Errorf("test transport error: connection refused"))
+
+	data, err := os.ReadFile(logFile)
+	if err != nil {
+		t.Fatalf("failed to read log file: %v", err)
+	}
+	log := string(data)
+
+	if !strings.Contains(log, "OTel SDK error") {
+		t.Errorf("log missing OTel SDK error line, got:\n%s", log)
+	}
+	if !strings.Contains(log, "connection refused") {
+		t.Errorf("log missing error details, got:\n%s", log)
+	}
+}
+
+func TestExportSessionTrace_DebugLogsSpanCount(t *testing.T) {
+	logFile := filepath.Join(t.TempDir(), "test.log")
+	logging.Init(logFile, true) // debug=true
+
+	exporter := tracetest.NewInMemoryExporter()
+	shutdown, flush, err := InitTracerWithExporter(exporter)
+	if err != nil {
+		t.Fatalf("InitTracerWithExporter: %v", err)
+	}
+	defer shutdown()
+
+	sessionID := "test-session-span-count"
+	now := time.Now()
+
+	// 1 turn with model + 1 tool = session(1) + turn(1) + LLM(1) + tool(1) = 4 spans
+	turns := []hook.Turn{
+		{
+			Number:    1,
+			Model:     "claude-sonnet-4-20250514",
+			StartTime: now,
+			EndTime:   now.Add(3 * time.Second),
+			ToolCalls: []hook.ToolCall{
+				{
+					Name:      "Read",
+					ID:        "toolu_001",
+					Success:   true,
+					StartTime: now.Add(500 * time.Millisecond),
+					EndTime:   now.Add(1 * time.Second),
+				},
+			},
+		},
+	}
+
+	ss := &hook.SessionState{}
+	ExportSessionTrace(sessionID, turns, nil, nil, ss, false)
+	flush()
+
+	data, err := os.ReadFile(logFile)
+	if err != nil {
+		t.Fatalf("failed to read log file: %v", err)
+	}
+	log := string(data)
+
+	if !strings.Contains(log, "ExportSessionTrace: spans=4") {
+		t.Errorf("log should show spans=4, got:\n%s", log)
+	}
+	if !strings.Contains(log, "turns=1") {
+		t.Errorf("log should show turns=1, got:\n%s", log)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add `Redact` and `RedactHeadersEnv` functions in `internal/logging/redact.go` for secret-safe debug output (key-based and value-based pattern matching)
- Log resolved endpoint URL, transport mode, all `OTEL_*` env var presence/values, and `CLAUDE_ENV_FILE` status at `InitTracer` when `CC_TRACE_DEBUG=true`
- Register `otel.SetErrorHandler` to capture async SDK transport errors and route to `logging.Debug`
- Log Shutdown error + duration with `sync.Once` guard (prevents duplicate logs from defer + explicit call)
- Log computed span count at `ExportSessionTrace`
- Update README `CC_TRACE_DEBUG` description with redaction patterns

## Test plan

- [x] 22 redaction unit tests (sensitive keys, sensitive values, non-sensitive truncation, header parsing)
- [x] 3 `logExportConfig` tests (HTTPS endpoint, default endpoint, CLAUDE_ENV_FILE)
- [x] 2 shutdown logging tests (logs once, sync.Once prevents duplicates)
- [x] 1 `otel.SetErrorHandler` test (routes SDK errors to debug log)
- [x] 1 span count test (ExportSessionTrace logs correct count)
- [x] All 55 existing tests pass with zero regressions
- [x] `go build`, `go vet`, `gofmt -s` clean

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)