### PR TITLE
fix: relay OTEL_* env vars via CC_TRACE_OTEL_* prefix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,13 +56,23 @@ Session Root
 
 ## Environment Variables
 
-All configuration follows the [OTel environment variable specification](https://opentelemetry.io/docs/languages/sdk-configuration/). The Go SDK reads these automatically.
+### OTel Config Relay (`CC_TRACE_OTEL_*`)
+
+Claude Code v2.1.128+ strips `OTEL_*` env vars from hook subprocesses. cc-trace works around this by reading `CC_TRACE_OTEL_*` vars at startup, stripping the `CC_TRACE_` prefix, and setting the corresponding `OTEL_*` var via `os.Setenv` — but only if the target is not already present (direct `OTEL_*` wins). This happens in `relayOtelEnv()` in `main.go`, before `InitTracer`.
 
 | Variable | OTel Spec Default | Purpose |
 |----------|-------------------|---------|
-| `OTEL_EXPORTER_OTLP_ENDPOINT` | `http://localhost:4318` | Base OTLP endpoint. Supports both `http://` and `https://` schemes. The HTTP exporter appends `/v1/traces` automatically. Shared with Claude Code's metrics/logs -- no separate traces endpoint needed. |
-| `OTEL_SERVICE_NAME` | `unknown_service` | `service.name` resource attribute |
-| `OTEL_RESOURCE_ATTRIBUTES` | (none) | Comma-separated `key=value` pairs added to the trace resource (e.g., `project.name=k8s-lab`) |
+| `CC_TRACE_OTEL_EXPORTER_OTLP_ENDPOINT` | `http://localhost:4318` | Base OTLP endpoint. HTTP exporter appends `/v1/traces` automatically. |
+| `CC_TRACE_OTEL_SERVICE_NAME` | `unknown_service` | `service.name` resource attribute |
+| `CC_TRACE_OTEL_RESOURCE_ATTRIBUTES` | (none) | Comma-separated `key=value` pairs added to the trace resource (e.g., `project.name=k8s-lab`) |
+| `CC_TRACE_OTEL_EXPORTER_OTLP_HEADERS` | (none) | Auth headers for OTLP requests (e.g., `Authorization=Bearer xxx`) |
+
+Any `CC_TRACE_OTEL_*` var is relayed — the mechanism is a mechanical prefix strip, not a whitelist.
+
+### cc-trace Settings
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
 | `CC_TRACE_DEBUG` | `false` | Debug logging to `~/.claude/state/cc_trace.log` |
 | `CC_TRACE_TIMING` | `false` | Phase-level timing logs to `~/.claude/state/cc_trace.log` (format: `total=Nms EventName session=... phase=Nms ...`) |
 | `CC_TRACE_DUMP` | `false` | Dump raw hook payloads and transcripts to `/tmp/cc-trace/dumps/` for investigation |

--- a/README.md
+++ b/README.md
@@ -58,26 +58,51 @@ Add to your global Claude Code settings (`~/.claude/settings.json`):
 
 ## Environment Variables
 
+### OTel Configuration (via `CC_TRACE_OTEL_*` relay)
+
+Claude Code v2.1.128+ strips all `OTEL_*` env vars from hook subprocesses. To pass OTel configuration to cc-trace, prefix them with `CC_TRACE_` — the hook strips the prefix at startup and sets the corresponding `OTEL_*` var before initializing the SDK. If a direct `OTEL_*` var is already present, it takes precedence.
+
 | Variable | Default | Purpose |
 |----------|---------|---------|
-| `OTEL_EXPORTER_OTLP_ENDPOINT` | `http://localhost:4318` | OTLP endpoint -- `http://` or `https://` (appends `/v1/traces`) |
-| `OTEL_SERVICE_NAME` | `unknown_service` | `service.name` resource attribute |
-| `OTEL_RESOURCE_ATTRIBUTES` | — | Comma-separated `key=value` pairs (e.g. `project.name=myapp`) |
-| `OTEL_EXPORTER_OTLP_HEADERS` | — | Comma-separated `key=value` headers for OTLP requests (e.g. `Authorization=Bearer xxx`). Read automatically by the OTel SDK |
-| `CC_TRACE_DEBUG` | `false` | Debug log to `~/.claude/state/cc_trace.log`. When enabled, logs resolved endpoint URL, transport mode (HTTP/HTTPS + insecure flag), presence and redacted values of all `OTEL_*` env vars, `CLAUDE_ENV_FILE` status, span export counts, Shutdown error/duration, and async OTel SDK transport errors. Sensitive values (keys matching `secret`, `token`, `bearer`, `authorization`, `cookie`, `api-key`, `client-secret`, or ending in `_KEY`) are redacted as `[REDACTED len=N]` |
+| `CC_TRACE_OTEL_EXPORTER_OTLP_ENDPOINT` | `http://localhost:4318` | OTLP endpoint -- `http://` or `https://` (appends `/v1/traces`) |
+| `CC_TRACE_OTEL_SERVICE_NAME` | `unknown_service` | `service.name` resource attribute |
+| `CC_TRACE_OTEL_RESOURCE_ATTRIBUTES` | — | Comma-separated `key=value` pairs (e.g. `project.name=myapp`) |
+| `CC_TRACE_OTEL_EXPORTER_OTLP_HEADERS` | — | Comma-separated `key=value` headers for OTLP requests (e.g. `Authorization=Bearer xxx`) |
+
+Any `CC_TRACE_OTEL_*` var works — the relay is mechanical, not a hardcoded whitelist.
+
+### cc-trace Settings
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `CC_TRACE_DEBUG` | `false` | Debug log to `~/.claude/state/cc_trace.log`. When enabled, logs relay activity, resolved endpoint URL, transport mode (HTTP/HTTPS + insecure flag), presence and redacted values of all `OTEL_*` env vars, span export counts, Shutdown error/duration, and async OTel SDK transport errors. Sensitive values (keys matching `secret`, `token`, `bearer`, `authorization`, `cookie`, `api-key`, `client-secret`, or ending in `_KEY`) are redacted as `[REDACTED len=N]` |
 | `CC_TRACE_TIMING` | `false` | Phase-level timing logs to `~/.claude/state/cc_trace.log` |
 | `CC_TRACE_DUMP` | `false` | Dump raw hook payloads and transcripts to `/tmp/cc-trace/dumps/` |
 | `CC_TRACE_ROTATE` | `false` | Rotate trace ID per session segment. Each SessionStart (startup/resume/clear/compact) on an existing session creates a new trace, preventing long-lived sessions from outliving backend retention. Search by `session.id` attribute to find all segments. Ignored when `TRACEPARENT` is set -- the external trace owns the trace ID. |
 | `TRACEPARENT` | — | [W3C Trace Context](https://www.w3.org/TR/trace-context/) parent. When set, the session trace becomes a child of the external trace (e.g. a CI pipeline span). Format: `00-<trace_id>-<span_id>-<flags>` |
 
-Set these per-project in `.claude/settings.json` under `"env"`, or export them in your shell:
+### Minimum Setup
+
+```jsonc
+// ~/.claude/settings.json
+{
+  "env": {
+    "CC_TRACE_OTEL_EXPORTER_OTLP_ENDPOINT": "https://otel.example.com",
+    "CC_TRACE_OTEL_EXPORTER_OTLP_HEADERS": "Authorization=Bearer YOUR_TOKEN"
+  }
+}
+```
+
+For a local collector on default port, no env vars are needed — the OTel SDK defaults to `http://localhost:4318`.
+
+Optional enrichment per-project in `.claude/settings.json`:
 
 ```jsonc
 // .claude/settings.json (project-level)
 {
   "env": {
-    "OTEL_SERVICE_NAME": "my-project",
-    "OTEL_RESOURCE_ATTRIBUTES": "project.name=my-project"
+    "CC_TRACE_OTEL_SERVICE_NAME": "my-project",
+    "CC_TRACE_OTEL_RESOURCE_ATTRIBUTES": "project.name=my-project"
   }
 }
 ```

--- a/cmd/cc-trace/main.go
+++ b/cmd/cc-trace/main.go
@@ -22,6 +22,30 @@ var (
 	dumpDir       = "/tmp/cc-trace/dumps"
 )
 
+const ccTraceOtelPrefix = "CC_TRACE_OTEL_"
+
+func relayOtelEnv() int {
+	count := 0
+	for _, entry := range os.Environ() {
+		if !strings.HasPrefix(entry, ccTraceOtelPrefix) {
+			continue
+		}
+		idx := strings.Index(entry, "=")
+		if idx < 0 {
+			continue
+		}
+		key := entry[:idx]
+		val := entry[idx+1:]
+		target := strings.TrimPrefix(key, "CC_TRACE_")
+		if _, exists := os.LookupEnv(target); exists {
+			continue
+		}
+		os.Setenv(target, val)
+		count++
+	}
+	return count
+}
+
 func main() {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
@@ -35,6 +59,12 @@ func main() {
 	timingEnabled := strings.EqualFold(os.Getenv("CC_TRACE_TIMING"), "true")
 	logging.Init(logFilePath, debugEnabled)
 	logging.InitTiming(timingEnabled)
+
+	relayed := relayOtelEnv()
+	if relayed > 0 {
+		logging.Debug(fmt.Sprintf("Relayed %d CC_TRACE_OTEL_* vars to OTEL_*", relayed))
+	}
+
 	state.Init(homeDir)
 
 	defer func() {

--- a/cmd/cc-trace/main_test.go
+++ b/cmd/cc-trace/main_test.go
@@ -394,6 +394,99 @@ func TestHandleSessionStart_RotateDisabled_NoOp(t *testing.T) {
 	}
 }
 
+func TestRelayOtelEnv_SingleVar(t *testing.T) {
+	t.Setenv("CC_TRACE_OTEL_EXPORTER_OTLP_ENDPOINT", "https://example.com")
+	os.Unsetenv("OTEL_EXPORTER_OTLP_ENDPOINT")
+
+	count := relayOtelEnv()
+
+	if count != 1 {
+		t.Errorf("relayOtelEnv() = %d, want 1", count)
+	}
+	got := os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT")
+	if got != "https://example.com" {
+		t.Errorf("OTEL_EXPORTER_OTLP_ENDPOINT = %q, want %q", got, "https://example.com")
+	}
+}
+
+func TestRelayOtelEnv_MultipleVars(t *testing.T) {
+	t.Setenv("CC_TRACE_OTEL_EXPORTER_OTLP_ENDPOINT", "https://example.com")
+	t.Setenv("CC_TRACE_OTEL_SERVICE_NAME", "my-service")
+	t.Setenv("CC_TRACE_OTEL_EXPORTER_OTLP_HEADERS", "Authorization=Bearer xxx")
+	os.Unsetenv("OTEL_EXPORTER_OTLP_ENDPOINT")
+	os.Unsetenv("OTEL_SERVICE_NAME")
+	os.Unsetenv("OTEL_EXPORTER_OTLP_HEADERS")
+
+	count := relayOtelEnv()
+
+	if count != 3 {
+		t.Errorf("relayOtelEnv() = %d, want 3", count)
+	}
+	if got := os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT"); got != "https://example.com" {
+		t.Errorf("OTEL_EXPORTER_OTLP_ENDPOINT = %q", got)
+	}
+	if got := os.Getenv("OTEL_SERVICE_NAME"); got != "my-service" {
+		t.Errorf("OTEL_SERVICE_NAME = %q", got)
+	}
+	if got := os.Getenv("OTEL_EXPORTER_OTLP_HEADERS"); got != "Authorization=Bearer xxx" {
+		t.Errorf("OTEL_EXPORTER_OTLP_HEADERS = %q", got)
+	}
+}
+
+func TestRelayOtelEnv_DirectEnvWins(t *testing.T) {
+	t.Setenv("CC_TRACE_OTEL_EXPORTER_OTLP_ENDPOINT", "https://relayed.com")
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "https://direct.com")
+
+	count := relayOtelEnv()
+
+	if count != 0 {
+		t.Errorf("relayOtelEnv() = %d, want 0 (direct env should win)", count)
+	}
+	got := os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT")
+	if got != "https://direct.com" {
+		t.Errorf("OTEL_EXPORTER_OTLP_ENDPOINT = %q, want %q (direct should be preserved)", got, "https://direct.com")
+	}
+}
+
+func TestRelayOtelEnv_IgnoresNonOtelPrefix(t *testing.T) {
+	t.Setenv("CC_TRACE_DEBUG", "true")
+	t.Setenv("CC_TRACE_TIMING", "true")
+	os.Unsetenv("DEBUG")
+	os.Unsetenv("TIMING")
+
+	count := relayOtelEnv()
+
+	if count != 0 {
+		t.Errorf("relayOtelEnv() = %d, want 0 (CC_TRACE_DEBUG/TIMING are not OTEL vars)", count)
+	}
+}
+
+func TestRelayOtelEnv_EmptyValue(t *testing.T) {
+	t.Setenv("CC_TRACE_OTEL_EXPORTER_OTLP_PROTOCOL", "")
+	os.Unsetenv("OTEL_EXPORTER_OTLP_PROTOCOL")
+
+	count := relayOtelEnv()
+
+	if count != 1 {
+		t.Errorf("relayOtelEnv() = %d, want 1 (empty value should still relay)", count)
+	}
+	val, ok := os.LookupEnv("OTEL_EXPORTER_OTLP_PROTOCOL")
+	if !ok {
+		t.Error("OTEL_EXPORTER_OTLP_PROTOCOL not set, want set with empty value")
+	}
+	if val != "" {
+		t.Errorf("OTEL_EXPORTER_OTLP_PROTOCOL = %q, want empty", val)
+	}
+}
+
+func TestRelayOtelEnv_NoVars(t *testing.T) {
+	count := relayOtelEnv()
+
+	if count != 0 {
+		t.Errorf("relayOtelEnv() = %d, want 0", count)
+	}
+}
+
 func TestHandleSessionStart_TraceparentSuppresses(t *testing.T) {
 	setupTestStateDir(t)
 	rotateEnabled = true

--- a/docs/plans/2026-05-19-001-fix-otel-env-relay-plan.md
+++ b/docs/plans/2026-05-19-001-fix-otel-env-relay-plan.md
@@ -1,0 +1,173 @@
+---
+title: "fix: Relay OTEL_* env vars via CC_TRACE_OTEL_* prefix"
+type: fix
+status: active
+date: 2026-05-19
+---
+
+# fix: Relay OTEL_* env vars via CC_TRACE_OTEL_* prefix
+
+## Overview
+
+Claude Code v2.1.128 intentionally strips all `OTEL_*` env vars from hook subprocesses to prevent OTel-instrumented apps from inheriting the CLI's telemetry config. cc-trace, as a hook, loses its export configuration. Fix by relaying via `CC_TRACE_OTEL_*` prefix, which passes through Claude Code's subprocess allowlist.
+
+## Problem Frame
+
+cc-trace hooks run to completion and log `[INFO] Exported N turns` but no spans arrive at the collector. The OTel SDK falls back to `http://localhost:4318/v1/traces` (its built-in default) because `OTEL_EXPORTER_OTLP_ENDPOINT` is absent from the hook subprocess environment.
+
+Root cause: Claude Code v2.1.128 (May 4, 2026) strips `OTEL_*` from all subprocesses (Bash, hooks, MCP, LSP). `CC_TRACE_*` and `CLAUDE_CODE_*` prefixes pass through. This is intentional, documented in the [release notes](https://github.com/anthropics/claude-code/releases/tag/v2.1.128).
+
+The `CLAUDE_ENV_FILE` mechanism mentioned in issue #30 is a write-back channel for hooks to inject vars into subsequent Bash tool commands — not a delivery mechanism for hook config. Sourcing it is not the correct fix.
+
+## Requirements Trace
+
+- R1. cc-trace must receive OTEL export configuration despite the v2.1.128 strip
+- R2. Users must be able to set `CC_TRACE_OTEL_*` vars in `settings.json` `env:` and have them reach the OTel SDK
+- R3. Direct `OTEL_*` env vars (if somehow present) must take precedence over relayed values
+- R4. The relay must work for any `OTEL_*` var without a hardcoded whitelist
+- R5. Debug logging from #31 must surface the relay activity
+
+## Scope Boundaries
+
+- No `CLAUDE_ENV_FILE` parsing — research confirmed it's not the right mechanism
+- No upstream changes to Claude Code — this is a cc-trace-side workaround
+- No new dependencies
+
+### Deferred to Separate Tasks
+
+- Upstream issue on `anthropics/claude-code` requesting hook exemption from `OTEL_*` strip: separate issue
+
+## Key Technical Decisions
+
+- **Mechanical prefix strip over whitelist**: Any env var matching `CC_TRACE_OTEL_*` gets `CC_TRACE_` stripped to produce the corresponding `OTEL_*` var. Predictable, zero maintenance, forwards-compatible with new OTel vars.
+- **Direct env wins**: Only set via `os.Setenv` if `os.LookupEnv` returns false for the target key. This ensures that if `OTEL_*` vars are somehow present (older Claude Code, wrapper script, CI), they take precedence.
+- **Relay runs once at startup, before InitTracer**: The relay is a one-shot env preparation step in `main()`, not a persistent mechanism.
+
+## Minimum User Configuration
+
+For cc-trace to export to a remote collector, the user needs at minimum:
+
+```jsonc
+// ~/.claude/settings.json
+{
+  "env": {
+    "CC_TRACE_OTEL_EXPORTER_OTLP_ENDPOINT": "https://otel.example.com",
+    "CC_TRACE_OTEL_EXPORTER_OTLP_HEADERS": "Authorization=Bearer xxx"
+  }
+}
+```
+
+Optional enrichment (sensible defaults exist):
+- `CC_TRACE_OTEL_SERVICE_NAME` (default: `unknown_service`)
+- `CC_TRACE_OTEL_RESOURCE_ATTRIBUTES` (default: none)
+- `CC_TRACE_OTEL_EXPORTER_OTLP_PROTOCOL` (default: `http/protobuf`)
+
+## Implementation Units
+
+- [x] **Unit 1: Add relay function and tests**
+
+**Goal:** Implement `relayOtelEnv()` that scans `os.Environ()` for `CC_TRACE_OTEL_*` vars, strips the `CC_TRACE_` prefix, and sets the corresponding `OTEL_*` var if not already present.
+
+**Requirements:** R1, R2, R3, R4
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `cmd/cc-trace/main.go`
+- Modify: `cmd/cc-trace/main_test.go`
+
+**Approach:**
+- New function `relayOtelEnv() int` in `main.go` that returns the count of vars relayed
+- Scan `os.Environ()` for entries starting with `CC_TRACE_OTEL_`
+- For each match: strip `CC_TRACE_` prefix to get target key, check `os.LookupEnv(target)`, set only if absent
+- Call from `main()` after logging init but before any code that reads `OTEL_*` vars
+
+**Patterns to follow:**
+- Existing env var reading pattern in `main()` lines 32-35 (`os.Getenv` + `strings.EqualFold`)
+- `os.LookupEnv` for presence check (distinguishes empty from absent)
+
+**Test scenarios:**
+- Happy path: `CC_TRACE_OTEL_EXPORTER_OTLP_ENDPOINT=https://example.com` is relayed to `OTEL_EXPORTER_OTLP_ENDPOINT`
+- Happy path: Multiple `CC_TRACE_OTEL_*` vars are all relayed
+- Edge case: Direct `OTEL_EXPORTER_OTLP_ENDPOINT` already set — relay does NOT overwrite (R3)
+- Edge case: `CC_TRACE_DEBUG=true` is NOT relayed (doesn't match `CC_TRACE_OTEL_` prefix)
+- Edge case: `CC_TRACE_OTEL_` with empty value — still set (empty is a valid value, distinct from absent)
+- Edge case: No `CC_TRACE_OTEL_*` vars present — clean no-op, returns 0
+
+**Verification:**
+- All tests pass
+- `relayOtelEnv` correctly distinguishes `CC_TRACE_OTEL_*` from `CC_TRACE_*`
+
+---
+
+- [x] **Unit 2: Integrate relay into main() and add debug logging**
+
+**Goal:** Wire `relayOtelEnv()` into the startup path and log relay activity via the existing debug logging infrastructure.
+
+**Requirements:** R5
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `cmd/cc-trace/main.go`
+
+**Approach:**
+- Call `relayOtelEnv()` in `main()` after `logging.Init` and before stdin read / event dispatch
+- Log one debug line: `"Relayed %d CC_TRACE_OTEL_* vars to OTEL_*"` (or `"No CC_TRACE_OTEL_* vars to relay"` when count is 0)
+- The existing `logExportConfig()` in `InitTracer` (from #31) will then show the resolved values — no duplication needed
+
+**Patterns to follow:**
+- Existing `logging.Debug()` calls in `main.go`
+
+**Test scenarios:**
+- Test expectation: none — integration is verified by Unit 1 tests and the existing #31 debug logging tests
+
+**Verification:**
+- With `CC_TRACE_DEBUG=true`, the relay log line appears before the `InitTracer` config dump
+- The `InitTracer` debug output shows the relayed endpoint, not the localhost default
+
+---
+
+- [x] **Unit 3: Update documentation**
+
+**Goal:** Document the `CC_TRACE_OTEL_*` relay in README and CLAUDE.md.
+
+**Requirements:** R1, R2
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `README.md`
+- Modify: `CLAUDE.md`
+
+**Approach:**
+- Add a section explaining the relay mechanism and why it exists (v2.1.128 strips `OTEL_*`)
+- Update the environment variables table to show `CC_TRACE_OTEL_*` as the recommended way to pass OTEL config
+- Document minimum configuration (endpoint + headers)
+- Remove or update the `CLAUDE_ENV_FILE` workaround from issue #30 if present
+
+**Test scenarios:**
+- Test expectation: none — documentation only
+
+**Verification:**
+- README clearly explains the minimum setup for a new user
+
+## System-Wide Impact
+
+- **Interaction graph:** The relay runs once in `main()` before any OTel SDK initialization. It affects `tracer.InitTracer()` which reads `OTEL_*` from env. The #31 `logExportConfig()` will naturally surface the relayed values.
+- **Error propagation:** No new error paths — `os.Setenv` doesn't fail in practice.
+- **Unchanged invariants:** All existing `CC_TRACE_*` vars (`DEBUG`, `TIMING`, `DUMP`, `ROTATE`) are unaffected — the relay only matches the `CC_TRACE_OTEL_` prefix, not `CC_TRACE_` broadly.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Future Claude Code version strips `CC_TRACE_*` too | Unlikely — `CC_TRACE_*` is a user-defined namespace, not an OTel convention. If it happens, upstream issue is the fix. |
+| User sets both `CC_TRACE_OTEL_*` and `OTEL_*` (via wrapper) | Direct `OTEL_*` wins per R3. No conflict. |
+
+## Sources & References
+
+- Related issue: #30 (this PR closes it)
+- Related PR: #32 (debug logging that surfaced the root cause)
+- Claude Code v2.1.128 release: https://github.com/anthropics/claude-code/releases/tag/v2.1.128
+- Claude Code OTel docs: https://code.claude.com/docs/en/agent-sdk/observability


### PR DESCRIPTION
## Summary

- Claude Code v2.1.128 intentionally strips all `OTEL_*` env vars from hook subprocesses, breaking cc-trace's ability to reach a remote collector
- Adds `relayOtelEnv()` that scans `CC_TRACE_OTEL_*` vars at startup, strips the `CC_TRACE_` prefix, and sets the corresponding `OTEL_*` var before OTel SDK init — only if the target var is not already present (direct env wins)
- Updates README and CLAUDE.md with the new `CC_TRACE_OTEL_*` configuration pattern and minimum setup example

## Minimum user configuration

```jsonc
// ~/.claude/settings.json
{
  "env": {
    "CC_TRACE_OTEL_EXPORTER_OTLP_ENDPOINT": "https://otel.example.com",
    "CC_TRACE_OTEL_EXPORTER_OTLP_HEADERS": "Authorization=Bearer YOUR_TOKEN"
  }
}
```

## Test plan

- [x] `TestRelayOtelEnv_SingleVar` — happy path: single var relayed
- [x] `TestRelayOtelEnv_MultipleVars` — happy path: 3 vars relayed simultaneously
- [x] `TestRelayOtelEnv_DirectEnvWins` — direct `OTEL_*` takes precedence, relay skipped
- [x] `TestRelayOtelEnv_IgnoresNonOtelPrefix` — `CC_TRACE_DEBUG`/`CC_TRACE_TIMING` not relayed
- [x] `TestRelayOtelEnv_EmptyValue` — empty string still relayed (distinct from absent)
- [x] `TestRelayOtelEnv_NoVars` — clean no-op, returns 0
- [x] Full test suite passes (`go test ./...`)

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)