### PR TITLE
fix: log relay source vars honestly

### DIFF
--- a/cmd/cc-trace/main.go
+++ b/cmd/cc-trace/main.go
@@ -38,9 +38,11 @@ func relayOtelEnv() int {
 		val := entry[idx+1:]
 		target := strings.TrimPrefix(key, "CC_TRACE_")
 		if _, exists := os.LookupEnv(target); exists {
+			logging.Debug(fmt.Sprintf("Relay skip: %s (direct %s already set)", key, target))
 			continue
 		}
 		os.Setenv(target, val)
+		logging.Debug(fmt.Sprintf("Relay: %s → %s=%s", key, target, logging.Redact(val, key)))
 		count++
 	}
 	return count
@@ -60,10 +62,7 @@ func main() {
 	logging.Init(logFilePath, debugEnabled)
 	logging.InitTiming(timingEnabled)
 
-	relayed := relayOtelEnv()
-	if relayed > 0 {
-		logging.Debug(fmt.Sprintf("Relayed %d CC_TRACE_OTEL_* vars to OTEL_*", relayed))
-	}
+	relayOtelEnv()
 
 	state.Init(homeDir)
 

--- a/cmd/cc-trace/main_test.go
+++ b/cmd/cc-trace/main_test.go
@@ -394,7 +394,21 @@ func TestHandleSessionStart_RotateDisabled_NoOp(t *testing.T) {
 	}
 }
 
+func setupRelayTest(t *testing.T) {
+	t.Helper()
+	logFile := filepath.Join(t.TempDir(), "test.log")
+	logging.Init(logFile, true)
+	for _, entry := range os.Environ() {
+		if strings.HasPrefix(entry, "CC_TRACE_OTEL_") {
+			key := entry[:strings.Index(entry, "=")]
+			t.Setenv(key, "")
+			os.Unsetenv(key)
+		}
+	}
+}
+
 func TestRelayOtelEnv_SingleVar(t *testing.T) {
+	setupRelayTest(t)
 	t.Setenv("CC_TRACE_OTEL_EXPORTER_OTLP_ENDPOINT", "https://example.com")
 	os.Unsetenv("OTEL_EXPORTER_OTLP_ENDPOINT")
 
@@ -410,6 +424,7 @@ func TestRelayOtelEnv_SingleVar(t *testing.T) {
 }
 
 func TestRelayOtelEnv_MultipleVars(t *testing.T) {
+	setupRelayTest(t)
 	t.Setenv("CC_TRACE_OTEL_EXPORTER_OTLP_ENDPOINT", "https://example.com")
 	t.Setenv("CC_TRACE_OTEL_SERVICE_NAME", "my-service")
 	t.Setenv("CC_TRACE_OTEL_EXPORTER_OTLP_HEADERS", "Authorization=Bearer xxx")
@@ -434,6 +449,7 @@ func TestRelayOtelEnv_MultipleVars(t *testing.T) {
 }
 
 func TestRelayOtelEnv_DirectEnvWins(t *testing.T) {
+	setupRelayTest(t)
 	t.Setenv("CC_TRACE_OTEL_EXPORTER_OTLP_ENDPOINT", "https://relayed.com")
 	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "https://direct.com")
 
@@ -449,6 +465,7 @@ func TestRelayOtelEnv_DirectEnvWins(t *testing.T) {
 }
 
 func TestRelayOtelEnv_IgnoresNonOtelPrefix(t *testing.T) {
+	setupRelayTest(t)
 	t.Setenv("CC_TRACE_DEBUG", "true")
 	t.Setenv("CC_TRACE_TIMING", "true")
 	os.Unsetenv("DEBUG")
@@ -462,6 +479,7 @@ func TestRelayOtelEnv_IgnoresNonOtelPrefix(t *testing.T) {
 }
 
 func TestRelayOtelEnv_EmptyValue(t *testing.T) {
+	setupRelayTest(t)
 	t.Setenv("CC_TRACE_OTEL_EXPORTER_OTLP_PROTOCOL", "")
 	os.Unsetenv("OTEL_EXPORTER_OTLP_PROTOCOL")
 
@@ -480,6 +498,7 @@ func TestRelayOtelEnv_EmptyValue(t *testing.T) {
 }
 
 func TestRelayOtelEnv_NoVars(t *testing.T) {
+	setupRelayTest(t)
 	count := relayOtelEnv()
 
 	if count != 0 {


### PR DESCRIPTION
## Summary

- `relayOtelEnv()` now logs each `CC_TRACE_OTEL_*` → `OTEL_*` relay with the original source var name and redacted value
- Logs skip reasons when direct `OTEL_*` vars take precedence
- Tests isolated from host environment `CC_TRACE_OTEL_*` vars

Previously the debug log only showed the post-relay `OTEL_*` names, making it look like they were set directly rather than relayed.

## Test plan

- [x] All 6 relay tests pass with host env isolation
- [x] Full test suite passes (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)