### PR TITLE
fix: annotate env vars as direct/relayed in debug log

### DIFF
--- a/internal/tracer/tracer.go
+++ b/internal/tracer/tracer.go
@@ -83,7 +83,11 @@ func logExportConfig() {
 		if val == "" {
 			logging.Debug(fmt.Sprintf("env: %s=(absent)", name))
 		} else {
-			logging.Debug(fmt.Sprintf("env: %s=%s (len=%d, present)", name, logging.Redact(val, name), len(val)))
+			source := "direct"
+			if _, relayed := os.LookupEnv("CC_TRACE_" + name); relayed {
+				source = "relayed"
+			}
+			logging.Debug(fmt.Sprintf("env: %s=%s (len=%d, %s)", name, logging.Redact(val, name), len(val), source))
 		}
 	}
 
@@ -96,7 +100,11 @@ func logExportConfig() {
 		if val == "" {
 			logging.Debug(fmt.Sprintf("env: %s=(absent)", name))
 		} else {
-			logging.Debug(fmt.Sprintf("env: %s=%s", name, logging.RedactHeadersEnv(val)))
+			source := "direct"
+			if _, relayed := os.LookupEnv("CC_TRACE_" + name); relayed {
+				source = "relayed"
+			}
+			logging.Debug(fmt.Sprintf("env: %s=%s (%s)", name, logging.RedactHeadersEnv(val), source))
 		}
 	}
 

--- a/internal/tracer/tracer_test.go
+++ b/internal/tracer/tracer_test.go
@@ -755,9 +755,9 @@ func TestLogExportConfig(t *testing.T) {
 		t.Errorf("log missing insecure=false, got:\n%s", log)
 	}
 
-	// Should log env vars with present/absent.
-	if !strings.Contains(log, "OTEL_EXPORTER_OTLP_ENDPOINT=") && !strings.Contains(log, "present") {
-		t.Errorf("log missing OTEL_EXPORTER_OTLP_ENDPOINT, got:\n%s", log)
+	// Should log env vars with source (direct/relayed).
+	if !strings.Contains(log, "OTEL_EXPORTER_OTLP_ENDPOINT=") || !strings.Contains(log, "direct") {
+		t.Errorf("log missing OTEL_EXPORTER_OTLP_ENDPOINT with direct source, got:\n%s", log)
 	}
 
 	// Headers should show keys but redact sensitive values.
@@ -774,6 +774,40 @@ func TestLogExportConfig(t *testing.T) {
 	// Absent vars should show (absent).
 	if !strings.Contains(log, "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=(absent)") {
 		t.Errorf("log missing absent TRACES_ENDPOINT, got:\n%s", log)
+	}
+}
+
+func TestLogExportConfig_RelayedSource(t *testing.T) {
+	logFile := filepath.Join(t.TempDir(), "test.log")
+	logging.Init(logFile, true)
+
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "https://otel.example.com")
+	t.Setenv("CC_TRACE_OTEL_EXPORTER_OTLP_ENDPOINT", "https://otel.example.com")
+	t.Setenv("OTEL_SERVICE_NAME", "test-service")
+	t.Setenv("CC_TRACE_OTEL_SERVICE_NAME", "test-service")
+	t.Setenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "")
+	t.Setenv("OTEL_EXPORTER_OTLP_HEADERS", "")
+	t.Setenv("OTEL_EXPORTER_OTLP_TRACES_HEADERS", "")
+	t.Setenv("OTEL_EXPORTER_OTLP_PROTOCOL", "")
+	t.Setenv("OTEL_RESOURCE_ATTRIBUTES", "")
+	t.Setenv("OTEL_EXPORTER_OTLP_CERTIFICATE", "")
+	t.Setenv("OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE", "")
+	t.Setenv("OTEL_EXPORTER_OTLP_CLIENT_KEY", "")
+	t.Setenv("CLAUDE_ENV_FILE", "")
+
+	logExportConfig()
+
+	data, err := os.ReadFile(logFile)
+	if err != nil {
+		t.Fatalf("failed to read log file: %v", err)
+	}
+	log := string(data)
+
+	if !strings.Contains(log, "OTEL_EXPORTER_OTLP_ENDPOINT=") || !strings.Contains(log, "relayed") {
+		t.Errorf("log should show relayed source for endpoint, got:\n%s", log)
+	}
+	if !strings.Contains(log, "OTEL_SERVICE_NAME=") || !strings.Contains(log, "relayed") {
+		t.Errorf("log should show relayed source for service name, got:\n%s", log)
 	}
 }
 


### PR DESCRIPTION
## Summary

- `logExportConfig()` now labels each `OTEL_*` var as `(direct)` or `(relayed)` by checking for the corresponding `CC_TRACE_OTEL_*` counterpart
- Replaces the misleading `(present)` annotation that made relayed vars look like they were set directly
- Adds test for relayed source annotation

Before:
```
env: OTEL_EXPORTER_OTLP_ENDPOINT=http://o...4318 (len=27, present)
```

After:
```
env: OTEL_EXPORTER_OTLP_ENDPOINT=http://o...4318 (len=27, relayed)
```

## Test plan

- [x] `TestLogExportConfig` — direct vars show `(direct)`
- [x] `TestLogExportConfig_RelayedSource` — relayed vars show `(relayed)`
- [x] Full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)