### PR TITLE
fix: remove duplicate (len=N) in env var debug log

### DIFF
--- a/internal/tracer/tracer.go
+++ b/internal/tracer/tracer.go
@@ -87,7 +87,7 @@ func logExportConfig() {
 			if _, relayed := os.LookupEnv("CC_TRACE_" + name); relayed {
 				source = "relayed"
 			}
-			logging.Debug(fmt.Sprintf("env: %s=%s (len=%d, %s)", name, logging.Redact(val, name), len(val), source))
+			logging.Debug(fmt.Sprintf("env: %s=%s (%s)", name, logging.Redact(val, name), source))
 		}
 	}
 


### PR DESCRIPTION
## Summary

- `Redact()` already appends `(len=N)` for truncated values, but `logExportConfig()` was adding its own `(len=%d, source)`, producing duplicate output like:
  ```
  env: OTEL_EXPORTER_OTLP_ENDPOINT=http://o ... 4318 (len=27) (len=27, relayed)
  ```
- Now shows cleanly:
  ```
  env: OTEL_EXPORTER_OTLP_ENDPOINT=http://o ... 4318 (len=27) (relayed)
  ```

## Test plan

- [x] Full test suite passes (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)